### PR TITLE
Adds Hook Event Dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -255,6 +255,7 @@
         "drupal/gin": "^3.0@RC",
         "drupal/gin_lb": "^1.0@RC",
         "drupal/gin_toolbar": "^1.0@RC",
+        "drupal/hook_event_dispatcher": "^4.0@RC",
         "drupal/layout_builder_modal": "^1.1",
         "drupal/media_library_form_element": "^2.0",
         "drupal/metatag": "^2.0",


### PR DESCRIPTION
Some hooks in custom modules break focal point functionality due to a bug in Core. With this change, the focal point preview on Person pages still works while allowing additional functionality needed via custom modules such as hiding the title and allowing the title to be created using a Person's First and Last Name fields. 

Includes:

- `tiamat10-project-template` => https://github.com/CuBoulder/tiamat10-project-template/pull/14
-  `tiamat-profile` => https://github.com/CuBoulder/tiamat10-profile/pull/27
- `ucb_person_title` => https://github.com/CuBoulder/ucb_person_title/pull/3

Resolves https://github.com/CuBoulder/ucb_person_title/issues/2, Resolves https://github.com/CuBoulder/tiamat-theme/issues/220