### PR TITLE
Fixes UCB Person page custom modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -233,6 +233,7 @@
         "cu-boulder/ucb_focal_image_enable": "dev-main",
         "cu-boulder/ucb_migration_shortcodes": "dev-main",
         "cu-boulder/ucb_person_title": "dev-main",
+        "cu-boulder/ucb_article_author": "dev-main",
         "cu-boulder/ucb_site_configuration": "dev-main",
         "cu-boulder/ucb_third_party_libraries": "dev-main",
         "cu-boulder/ucb_user_invite": "dev-main",


### PR DESCRIPTION
Adds the fixed versions of `UCB Person Title` and `UCB Article Author` to template and profile. Allows First and Last Name fields to create a Person Page title, getting rid of the need to enter a title for these pages. Also automatically creates a Byline taxonomy for newly created Person Pages, for use in the Byline field. 

Includes:

- `tiamat10-project-template` => https://github.com/CuBoulder/tiamat10-project-template/pull/15 (`issue/ucb_person_title/2`)
-  `tiamat-profile` => https://github.com/CuBoulder/tiamat10-profile/pull/28 (`issue/ucb_person_title/2`)
-  `ucb_person_title` => https://github.com/CuBoulder/ucb_person_title/pull/4 (`issue/2`)
-  `ucb_article_author` => https://github.com/CuBoulder/ucb_article_author/pull/2 (`issue/1`)

Resolves https://github.com/CuBoulder/ucb_article_author/issues/1, Resolves https://github.com/CuBoulder/ucb_person_title/issues/2