### PR TITLE
Adds Menu First Child Module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -262,6 +262,7 @@
         "drupal/media_file_delete": "^1.3",
         "drupal/media_library_form_element": "^2.0",
         "drupal/menu_block": "^1.10",
+        "drupal/menu_firstchild": "^2.1",
         "drupal/metatag": "^2.0",
         "drupal/migrate_plus": "^6.0",
         "drupal/migrate_tools": "^6.0",


### PR DESCRIPTION
Adds the Menu First Child module: 

How to use:
- Navigate to admin/structure/menu and choose the menu you want to customize.
- Add a new menu link or edit an existing link then enter <firstchild> as the link path to turn it into a parent item linking to its first accessible child.

Resolves https://github.com/CuBoulder/tiamat-theme/issues/637

Includes:
- `express-admin` (issue/tiamat-theme/637) => https://github.com/CuBoulder/express_admin/pull/4
- `tiamat10-profile`(issue/tiamat-theme/637) => https://github.com/CuBoulder/tiamat10-profile/pull/70
- `tiamat10-project template` (issue/tiamat-theme/637) => https://github.com/CuBoulder/tiamat10-project-template/pull/31