### PR TITLE
Adds "Administer Users by Role" contrib module

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -36,7 +36,7 @@ services:
       - composer install
 config:
   php: '8.2'
-  composer_version: '2.6.6'
+  composer_version: '2.7.1'
   webroot: web
   database: mariadb
   xdebug: false

--- a/composer.json
+++ b/composer.json
@@ -240,6 +240,7 @@
         "cu-boulder/ucb_user_invite": "dev-main",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.4",
+        "drupal/administerusersbyrole": "^3.4",
         "drupal/aggregator": "^2.0",
         "drupal/antibot": "^2.0",
         "drupal/better_social_sharing_buttons": "^4.0",


### PR DESCRIPTION
Allows Site Managers to configure users with an equal or lower permission level, including adding or removing roles of an equal or lower permission level.

CuBoulder/tiamat10-profile#78

Sister PR in: [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/79)