### PR TITLE
Adds "Google Tag" contrib module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -257,6 +257,7 @@
         "drupal/field_group": "^3.1",
         "drupal/focal_point": "^2.0",
         "drupal/google_cse": "^4.0@alpha",
+        "drupal/google_tag": "^2.0",
         "drupal/layout_builder_iframe_modal": "^1.3",
         "drupal/linkit": "^6.1",
         "drupal/media_alias_display": "^2.0",


### PR DESCRIPTION
Adds [Google Tag](https://www.drupal.org/project/google_tag) contrib module to serve Google Analytics 4 trackers. The settings were copied over to match D7 Express. Only Architects and Developers can configure Google Tag.

CuBoulder/tiamat10-profile#90

Sister PR in: [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/91)