### PR TITLE
Adds Rebuild Cache Access contrib module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -284,6 +284,7 @@
         "drupal/pantheon_advanced_page_cache": "^2.0",
         "drupal/paragraphs": "^1.14",
         "drupal/pathauto": "^1.8",
+        "drupal/rebuild_cache_access": "^1.10",
         "drupal/recaptcha_v3": "^2.0",
         "drupal/redirect": "^1.8",
         "drupal/responsive_preview": "^2.1",


### PR DESCRIPTION
This new contrib module adds a "Rebuild Cache" option in the toolbar, accessible to architects and developers. **Use this sparingly and only as a last resort after you've tried everything else, such as clearing local browser caches. A cache rebuild is an administrative action that has temporary negative effects on the performance of the site.**

CuBoulder/tiamat10-profile#147

Sister PR in: [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/148)