### PR TITLE
Add required module for mega menu

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -278,6 +278,7 @@
         "drupal/media_library_form_element": "^2.0",
         "drupal/menu_block": "^1.10",
         "drupal/menu_firstchild": "^2.1",
+        "drupal/menu_item_extras": "^3.0",
         "drupal/metatag": "^2.0",
         "drupal/migrate_devel": "^2.3",
         "drupal/migrate_plus": "^6.0",


### PR DESCRIPTION
Closes https://github.com/CuBoulder/tiamat-theme/issues/629.
Adds the mega menu module to the composer json.