### PR TITLE
Remove Entity Embed Patch

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -36,7 +36,7 @@ services:
     build:
       - composer install
 config:
-  php: '8.2'
+  php: '8.3'
   composer_version: '2.7.7'
   webroot: web
   database: mariadb

--- a/composer.json
+++ b/composer.json
@@ -337,10 +337,7 @@
         "patches": {
             "drupal/core": {
                 "Reusable Patch Beta": "https://www.drupal.org/files/issues/2024-01-23/add_reusable_option_to_inline_block_creation-2999491-141.patch"
-            },
-        "drupal/entity_embed":{
-               "patch": "https://www.drupal.org/files/issues/2024-08-07/entity_embed-embed_constructor-3466609-8.patch"
-           }
+            }
         },
         "patchLevel": {
             "drupal/core": "-p2"


### PR DESCRIPTION
No longer needed as they reverted the change in the parent Entity module.  

Also bumping PHP to 8.3 