### PR TITLE
Adds CU Boulder Styled Block custom module and updates block styles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -247,6 +247,7 @@
         "cu-boulder/ucb_migration_shortcodes": "dev-main",
         "cu-boulder/ucb_person_title": "dev-main",
         "cu-boulder/ucb_site_configuration": "dev-main",
+        "cu-boulder/ucb_styled_block": "dev-main",
         "cu-boulder/ucb_third_party_libraries": "dev-main",
         "cu-boulder/ucb_user_invite": "dev-main",
         "cweagans/composer-patches": "^1.7",


### PR DESCRIPTION
This update:
- [new] Adds the new CU Boulder Styled Block custom module.
- [new] Converts the Campus News block to a styled block, adding new style options to match our other blocks. CuBoulder/ucb_campus_news#6 CuBoulder/ucb_campus_news#9
- [change] Refactors existing styled blocks to all extend the same Twig template with Twig inheritance.
- [change] Corrects some indentation and other minor code style issues in affected block templates.

Sister PR in: [ucb_campus_news](https://github.com/CuBoulder/ucb_campus_news/pull/10), [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/1209), [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/187)