### PR TITLE
#82 - Remove name from config.yaml, update README

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,5 +1,4 @@
 ---
-name: tiamat10-test
 type: drupal10
 docroot: web
 php_version: "8.3"

--- a/README.md
+++ b/README.md
@@ -7,13 +7,11 @@ composer -v             # verify that you have have composer 2.x installed
 
 composer self-update    # update composer to the latest version (if necessary)
 
-git clone <project-name> # You will need to match the <project-name> with a later field
+git clone <project-name> # This will become the name of your containers (ddev-<project-name>)
 
 cd <project-name>
 
-open .ddev/config.yaml and replace the name value on line 1 with the same <project-name>
-
-ddev start              # will spin up the containers
+ddev start              # will spin up the containers: ddev-<project-name>
 
 ddev composer install   # will pull in all the modules
 


### PR DESCRIPTION
Removes the `name` key from `.ddev/config.yaml` so that the project will take the name of the directory it's in, which should help to avoid mutagen caching conflicts. Updates the Installation Instructions in our README.md to reflect this setup change. 

Resolves #82 